### PR TITLE
feat: Update installHook to install pre-push hook and improve error handling

### DIFF
--- a/src/commands/install-hook.ts
+++ b/src/commands/install-hook.ts
@@ -1,14 +1,41 @@
-import { chmodSync, writeFileSync } from "fs";
+import { chmodSync, existsSync, writeFileSync } from "fs";
 import { join } from "path";
 
-export async function installHook() {
-  const hookPath = join(process.cwd(), ".git/hooks/pre-commit");
+const HOOK_SCRIPT = `#!/bin/sh
+# Installed by typequake — do not edit this line
+typequake $(git rev-parse --abbrev-ref HEAD@{upstream} 2>/dev/null || echo "HEAD~1")
+`;
 
-  const script = `#!/bin/sh
-  typequake $(git rev-parse --abbrev-ref HEAD@{upstream})`;
+const HOOK_MARKER = "# Installed by typequake";
 
-  writeFileSync(hookPath, script, { encoding: "utf-8" });
+export async function installHook(): Promise<void> {
+  const gitDir = join(process.cwd(), ".git");
+
+  if (!existsSync(gitDir)) {
+    process.stderr.write(
+      "typequake: no .git directory found. Run this command from the root of a git repository.\n",
+    );
+    process.exit(1);
+  }
+
+  const hookPath = join(gitDir, "hooks", "pre-push");
+
+  // Safe overwrite: if a hook exists and was NOT installed by typequake, abort.
+  if (existsSync(hookPath)) {
+    const { readFileSync } = await import("fs");
+    const existing = readFileSync(hookPath, "utf-8");
+
+    if (!existing.includes(HOOK_MARKER)) {
+      process.stderr.write(
+        `typequake: a pre-push hook already exists at ${hookPath} and was not installed by typequake.\n` +
+          `Remove it manually and re-run if you want to replace it.\n`,
+      );
+      process.exit(1);
+    }
+  }
+
+  writeFileSync(hookPath, HOOK_SCRIPT, { encoding: "utf-8" });
   chmodSync(hookPath, 0o755);
 
-  console.log("Pre-commit hook installed successfully.");
+  process.stdout.write(`typequake: pre-push hook installed at ${hookPath}\n`);
 }


### PR DESCRIPTION
Happy path — fresh install:
```
ronnie @ Workspace/test (main) > bun run ~/Desktop/Workspace/typequake/src/cli.ts install-hook
typequake: pre-push hook installed at /Users/ronnie/Desktop/Workspace/test/.git/hooks/pre-push

ronnie @ Workspace/test (main) > cat .git/hooks/pre-push
#!/bin/sh
# Installed by typequake — do not edit this line
typequake $(git rev-parse --abbrev-ref HEAD@{upstream} 2>/dev/null || echo "HEAD~1")

ronnie @ Workspace/test (main) > ls -la .git/hooks/pre-push
-rwxr-xr-x@ 1 ronnie  staff  146 31 Mar 18:55 .git/hooks/pre-push
```

Idempotent re-install:
```
ronnie @ Workspace/test (main) > bun run ~/Desktop/Workspace/typequake/src/cli.ts install-hook
typequake: pre-push hook installed at /Users/ronnie/Desktop/Workspace/test/.git/hooks/pre-push
```

Safe overwrite — existing foreign hook:
```
ronnie @ Workspace/test (main) > echo '#!/bin/sh\necho "my custom hook"' > .git/hooks/pre-push
ronnie @ Workspace/test (main) > chmod +x .git/hooks/pre-push

ronnie @ Workspace/test (main) > bun run ~/Desktop/Workspace/typequake/src/cli.ts install-hook
typequake: a pre-push hook already exists at /Users/ronnie/Desktop/Workspace/test/.git/hooks/pre-push and was not installed by typequake.
Remove it manually and re-run if you want to replace it.
```

Outside a git repo:
```
ronnie @ Desktop/Workspace  > bun run ~/Desktop/Workspace/typequake/src/cli.ts install-hook
typequake: no .git directory found. Run this command from the root of a git repository.
```

Verify the hook runs on push:
```
ronnie @ Workspace/test (main) > git remote add origin git@github.com:pyronlaboratory/super-goggles.git
ronnie @ Workspace/test (main) > git commit --allow-empty -m "test"
ronnie @ Workspace/test (main) > git push --set-upstream origin main

typequake  base: HEAD~1

✔  No consumer impact detected.

✔  No type mutations detected.

Enumerating objects: 69, done.
Counting objects: 100% (69/69), done.
Delta compression using up to 8 threads
Compressing objects: 100% (56/56), done.
Writing objects: 100% (69/69), 7.33 KiB | 3.67 MiB/s, done.
Total 69 (delta 8), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (8/8), done.
To github.com:pyronlaboratory/super-goggles.git
 * [new branch]      main -> main
branch 'main' set up to track 'origin/main'.
```